### PR TITLE
Don't hardcode cd to 'tests' in bash script. Make it flexible as possible

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,15 +1,6 @@
 #!/usr/bin/env /bin/sh
 
-SOURCE="${BASH_SOURCE[0]}"
-# While $SOURCE is a symlink, resolve it
-while [ -h "$SOURCE" ]; do
-    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-    SOURCE="$( readlink "$SOURCE" )"
-    # If $SOURCE was a relative symlink (so no "/" as prefix, need to resolve it relative to the symlink base directory
-    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
-done
-DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
-cd $DIR;
+cd $(dirname $0);
 
 ACTUAL=$(php console.php signature-configured:optional-array-argument-command foo bar)
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env /bin/sh
 
-cd tests;
+SOURCE="${BASH_SOURCE[0]}"
+# While $SOURCE is a symlink, resolve it
+while [ -h "$SOURCE" ]; do
+    DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+    SOURCE="$( readlink "$SOURCE" )"
+    # If $SOURCE was a relative symlink (so no "/" as prefix, need to resolve it relative to the symlink base directory
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+cd $DIR;
 
 ACTUAL=$(php console.php signature-configured:optional-array-argument-command foo bar)
 


### PR DESCRIPTION
Original solution source: http://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in

Travis failed so reverted back to simpler solution.